### PR TITLE
New fixes to Inference Scaling tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,26 @@ the next 100 are measured for inference throughput.
 The input parameters to the test are used to generate permutations
 of tests with varying configurations.
 
+### The model
+As Neural Network, we use Pytorch's implementation of Resnet50. The script `imagenet/model_saver.py`
+can be used to generate the model for CPU or GPU. It can be invoked with
+
+```bash
+python model_saver.py
+```
+
+to generate the model for CPU, or with
+
+```bash
+python model_saver.py --device=CPU
+```
+
+for the GPU model. If the benchmark driver is executed and
+no model exists, an attempt is made to generate the model on the fly. In both cases,
+the specified device must be available on the node where the script is called (this
+means that it could be required to run the script through the worload manager launcher
+to execute it on a node with a GPU, for example).
+
 ### Co-located inference
 
 Co-located Orchestrators are deployed on the same nodes as the

--- a/cpp-inference/inference_scaling_imagenet.cpp
+++ b/cpp-inference/inference_scaling_imagenet.cpp
@@ -92,16 +92,14 @@ void run_mnist(const std::string& model_name,
       for (int i=0; i<num_devices; i++ ) {
         std::string model_key = "resnet_model_" + std::to_string(i);
         std::string script_key = "resnet_script_" + std::to_string(i);
-        std::string device_key = device + ":" + std::to_string(i);
-        std::cout<<"Device Key " <<device_key <<std::endl<<std::flush;
-
+        std::string model_name = "./resnet50." + device + ".pt";
         if (use_multi) {
-          client.set_model_from_file_multigpu(model_key, "./resnet50.pt", "TORCH", 0, num_devices, batch_size);
+          client.set_model_from_file_multigpu(model_key, model_name, "TORCH", 0, num_devices, batch_size);
           client.set_script_from_file_multigpu(script_key, "./data_processing_script.txt", 0, num_devices);
 	      }  
         else {
-          client.set_model_from_file(model_key, "./resnet50.pt", "TORCH", device_key, batch_size);
-          client.set_script_from_file(script_key, device_key, "./data_processing_script.txt");
+          client.set_model_from_file(model_key, model_name, "TORCH", device, batch_size);
+          client.set_script_from_file(script_key, device, "./data_processing_script.txt");
         }
         
       }

--- a/driver.py
+++ b/driver.py
@@ -769,7 +769,6 @@ def setup_resnet(model, device, num_devices, batch_size, address, cluster=True):
     else:
         devices = []
         if num_devices > 1:
-        if num_devices > 1:
             devices = [f"{device.upper()}:{str(i)}" for i in range(num_devices)]
         else:
             devices = [device.upper()]

--- a/imagenet/model_saver.py
+++ b/imagenet/model_saver.py
@@ -1,13 +1,27 @@
 import torchvision.models as models
 import torch
-print("USING CUDA", torch.cuda.is_available())
+import fire
+import os
 
-model = models.resnet50(pretrained=True)
-model.cuda()
-model.to(torch.device("cuda"))
-model.eval()
+def save_model(device: str = "GPU"):
+    print(f"Saving model for {device}")
+    if device.startswith("GPU"):
+        if not torch.cuda.is_available():
+            raise Exception("Requested to create GPU model, but CUDA was not found.")
+    # Device's torch name
+    device_name = "cuda" if device.startswith("GPU") else "cpu"
+    model = models.resnet50(pretrained=True)
+    model.to(torch.device(device_name))
+    model.eval()
 
-batch = torch.randn((1, 3, 224, 224)).cuda()
-batch.to(torch.device("cuda"))
-traced_model = torch.jit.trace(model, batch)
-torch.jit.save(traced_model, 'resnet50.pt')
+    batch = torch.randn((1, 3, 224, 224), device=device_name)
+    traced_model = torch.jit.trace(model, batch)
+
+    path = os.path.dirname(os.path.realpath(__file__))
+    torch.jit.save(traced_model, os.path.join(path, f'resnet50.{device[0:3]}.pt'))
+    print("model saved")
+    del model
+
+if __name__ == '__main__':
+    print("Welcome to model saver!")
+    fire.Fire(save_model)


### PR DESCRIPTION
This PR includes some fixes for inference scaling tests. Moreover, the `model_saver.py` script is now called from `driver.py` when the model is missing and an error is returned if that's not possible because a GPU is not available locally.