### PR TITLE
Update model_saver.py

### DIFF
--- a/imagenet/model_saver.py
+++ b/imagenet/model_saver.py
@@ -22,7 +22,7 @@ def save_model(device: str = "CPU", model_name = "resnet50"):
     # Device's torch name
     device_name = "cuda" if device.startswith("GPU") else "cpu"
 
-    model = getattr(models)(pretrained=True)
+    model = getattr(models, model_name)(pretrained=True)
     model.to(torch.device(device_name))
     model.eval()
 


### PR DESCRIPTION
The getattr option on models was added to allow users to  specify different Imagenet models for the scaling study. This clearly was not tested as the syntax is not correct and missing the retrieval of the model_name. This patch fixes this line.